### PR TITLE
Allow request timeout modification in server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -30,6 +30,7 @@ module.exports = function(options) {
     function start(cb) {
         logger.info(format('Starting server on %s:%d', config.host, config.port))
         server = app.listen(config.port, config.host, cb)
+        config.hasOwnProperty('requestTimeout') && (server.requestTimeout = config.requestTimeout)
         enableDestroy(server)
     }
 


### PR DESCRIPTION
### Main changes
- :new: (feat)

### Additional info

With this change we want to make the request timeout of the server configurable. This is needed because server request timeout has changed from Node.js v18. Now it is set to 300000 milliseconds (5 minutes) by default. See [docs](https://fek.io/blog/what-is-new-in-node-js-18/).

Our current use case is that we have an upload asset endpoint that takes some time to upload a file, so with this default timeout the request was failing with a "Request timeout" error with big files. That's why we need to customise this timeout value.

This value can be configurable in config.js

<img width="766" alt="Captura de pantalla 2024-02-13 a las 10 12 31" src="https://github.com/onebeyond/systemic-express/assets/39806058/b721bea6-901d-44b4-9797-9809e78b73de">




