### PR TITLE
fix: replace deprecated Boom.wrap call

### DIFF
--- a/lib/default-middleware.js
+++ b/lib/default-middleware.js
@@ -39,7 +39,7 @@ module.exports = function(options) {
             err.output.payload.message = err.message
             err.output.payload.stack = err.stack
         }
-        has(res, 'locals.logger') ? res.locals.logger.log(err) : logger.log(err)
+        has(res, 'locals.logger') ? res.locals.logger.error(err) : logger.error(err)
         dispatch(err, req, res)
     }
 

--- a/lib/default-middleware.js
+++ b/lib/default-middleware.js
@@ -33,7 +33,7 @@ module.exports = function(options) {
     }
 
     function errorMiddleware(err, req, res, next) {
-        err = Boom.wrap(err)
+        err = Boom.boomify(err)
         // https://github.com/hapijs/boom/issues/39
         if (config.showErrorDetail) {
             err.output.payload.message = err.message
@@ -54,5 +54,3 @@ module.exports = function(options) {
         start: async.seq(init, validate, start)
     }
 }
-
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systemic-express",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A systemic express component",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Main changes

- :bug: (fix)

### Additional notes

This PR resolves #20, which relates to the following error that sometimes show up when using this module:

```
TypeError: Boom.wrap is not a function
    at errorMiddleware (C:\Development\app-he-hoges-web\node_modules\systemic-express\lib\default-middleware.js:36:20)
    at Layer.handle_error (C:\Development\app-he-hoges-web\node_modules\express\lib\router\layer.js:71:5)
    at trim_prefix (C:\Development\app-he-hoges-web\node_modules\express\lib\router\index.js:326:13)
    at C:\Development\app-he-hoges-web\node_modules\express\lib\router\index.js:286:9
    at Function.process_params (C:\Development\app-he-hoges-web\node_modules\express\lib\router\index.js:346:12)
    at next (C:\Development\app-he-hoges-web\node_modules\express\lib\router\index.js:280:10)
    at Layer.handle_error (C:\Development\app-he-hoges-web\node_modules\express\lib\router\layer.js:67:12)
    at trim_prefix (C:\Development\app-he-hoges-web\node_modules\express\lib\router\index.js:326:13)
    at C:\Development\app-he-hoges-web\node_modules\express\lib\router\index.js:286:9
    at Function.process_params (C:\Development\app-he-hoges-web\node_modules\express\lib\router\index.js:346:12)
```

This issue was pressumably introduced in #13, which upgraded the `boom` package from [version 3.2.2 to 10.0.0](https://github.com/hapijs/boom/compare/v3.2.2...v10.0.0). `Boom.wrap` has long became deprecated and replaced by `Boom.boomify`.

This also replaces the `logger.log` calls in the default error middleware which were causing this exception and the errors not to properly be displayed:

```
TypeError: logger.log is not a function
    at errorMiddleware (C:\Development\app-he-hoges-web\node_modules\systemic-express\lib\default-middleware.js:42:73)
```